### PR TITLE
Add initial React Native screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,24 @@
+import 'react-native-gesture-handler';
+import * as React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createDrawerNavigator } from '@react-navigation/drawer';
+
+import HomeScreen from './src/screens/HomeScreen';
+import ChatScreen from './src/screens/ChatScreen';
+import BroadcastsScreen from './src/screens/BroadcastsScreen';
+import PaymentsScreen from './src/screens/PaymentsScreen';
+
+const Drawer = createDrawerNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Drawer.Navigator initialRouteName="Home">
+        <Drawer.Screen name="Home" component={HomeScreen} />
+        <Drawer.Screen name="Student Chat" component={ChatScreen} />
+        <Drawer.Screen name="Broadcasts" component={BroadcastsScreen} />
+        <Drawer.Screen name="Payments" component={PaymentsScreen} />
+      </Drawer.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# spa-app
+# University Mobile App
+
+This project is a cross-platform mobile application for a university. It is built with React Native using Expo. The app currently provides placeholder screens for:
+
+- Student Chat
+- Broadcasts
+- Payments
+
+## Development
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the Expo development server:
+
+   ```bash
+   npm start
+   ```
+
+This will launch Expo where you can run the app on Android, iOS, or the web.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "university-app",
+  "version": "0.1.0",
+  "main": "App.js",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.71.8",
+    "react-native-gesture-handler": "^2.8.0",
+    "react-native-safe-area-context": "^4.5.0",
+    "react-native-screens": "^3.18.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/drawer": "^6.6.2"
+  }
+}

--- a/src/screens/BroadcastsScreen.js
+++ b/src/screens/BroadcastsScreen.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function BroadcastsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Broadcasts</Text>
+      <Text style={styles.placeholder}>
+        This screen will show announcements from the university.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  placeholder: {
+    marginTop: 8,
+    fontStyle: 'italic',
+    textAlign: 'center',
+  },
+});

--- a/src/screens/ChatScreen.js
+++ b/src/screens/ChatScreen.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ChatScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Student Chat</Text>
+      <Text style={styles.placeholder}>Chat feature coming soon.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  placeholder: {
+    marginTop: 8,
+    fontStyle: 'italic',
+  },
+});

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>University App</Text>
+      <Text style={styles.subtitle}>
+        Welcome! Use the menu to navigate through the app.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  subtitle: {
+    fontSize: 16,
+    marginTop: 8,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/PaymentsScreen.js
+++ b/src/screens/PaymentsScreen.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button, Linking } from 'react-native';
+
+export default function PaymentsScreen() {
+  const handlePay = () => {
+    Linking.openURL('https://example.com/payments');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Payments</Text>
+      <Text style={styles.placeholder}>
+        Outstanding balance: TBD
+      </Text>
+      <Button title="Pay Online" onPress={handlePay} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  placeholder: {
+    marginTop: 8,
+    marginBottom: 16,
+    fontStyle: 'italic',
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- initialize React Native expo project skeleton
- add drawer navigation with Home, Student Chat, Broadcasts, and Payments screens
- document setup instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6855c5bd287c832484aab984faf96dde