### PR TITLE
Fix blank screen by adding GestureHandlerRootView

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,6 +2,7 @@ import 'react-native-gesture-handler';
 import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createDrawerNavigator } from '@react-navigation/drawer';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import HomeScreen from './src/screens/HomeScreen';
 import ChatScreen from './src/screens/ChatScreen';
@@ -12,13 +13,15 @@ const Drawer = createDrawerNavigator();
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <Drawer.Navigator initialRouteName="Home">
-        <Drawer.Screen name="Home" component={HomeScreen} />
-        <Drawer.Screen name="Student Chat" component={ChatScreen} />
-        <Drawer.Screen name="Broadcasts" component={BroadcastsScreen} />
-        <Drawer.Screen name="Payments" component={PaymentsScreen} />
-      </Drawer.Navigator>
-    </NavigationContainer>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NavigationContainer>
+        <Drawer.Navigator initialRouteName="Home">
+          <Drawer.Screen name="Home" component={HomeScreen} />
+          <Drawer.Screen name="Student Chat" component={ChatScreen} />
+          <Drawer.Screen name="Broadcasts" component={BroadcastsScreen} />
+          <Drawer.Screen name="Payments" component={PaymentsScreen} />
+        </Drawer.Navigator>
+      </NavigationContainer>
+    </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the drawer navigator in `GestureHandlerRootView`

## Testing
- `node -c App.js`
- `npx expo start --offline` *(fails: "Domain forbidden" when trying to reach expo servers)*

------
https://chatgpt.com/codex/tasks/task_b_6855cd3d7fbc8324828fd3b40ac88639