### PR TITLE
Fix missing AppRegistry registration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "university-app",
   "version": "0.1.0",
-  "main": "App.js",
+  "main": "index.js",
   "private": true,
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- set `index.js` as the entry point so React Native registers the app
- register the root component with Expo

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6855e698ab2c8324802da36ab2663710