### PR TITLE
Add react-native-reanimated setup

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import 'react-native-reanimated';
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "18.2.0",
         "react-native": "0.71.8",
         "react-native-gesture-handler": "^2.8.0",
+        "react-native-reanimated": "^3.18.0",
         "react-native-safe-area-context": "^4.5.0",
         "react-native-screens": "^3.18.0",
         "react-native-web": "~0.18.10"
@@ -12935,7 +12936,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
       "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -12945,7 +12945,6 @@
       "version": "3.18.0",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.18.0.tgz",
       "integrity": "sha512-eVcNcqeOkMW+BUWAHdtvN3FKgC8J8wiEJkX6bNGGQaLS7m7e4amTfjIcqf/Ta+lerZLurmDaQ0lICI1CKPrb1Q==",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/drawer": "^6.6.2",
     "react-native-web": "~0.18.10",
-    "@expo/webpack-config": "^18.0.1"
+    "@expo/webpack-config": "^18.0.1",
+    "react-native-reanimated": "^3.18.0"
   }
 }


### PR DESCRIPTION
## Summary
- add babel config enabling `react-native-reanimated`
- use side-effect import for `react-native-reanimated` in `index.js`
- declare `react-native-reanimated` dependency

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: network access to `api.expo.dev` blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6855fb7bd0d0832497ecf59037a77e4a