### PR TITLE
Add initial UI screens

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,27 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="chat"
+        options={{
+          title: 'Chat',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="bubble.left.and.bubble.right.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="broadcast"
+        options={{
+          title: 'Broadcast',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="megaphone.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="payments"
+        options={{
+          title: 'Payments',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="creditcard.fill" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/broadcast.tsx
+++ b/app/(tabs)/broadcast.tsx
@@ -1,0 +1,25 @@
+import { StyleSheet } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function BroadcastScreen() {
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title">Broadcasts</ThemedText>
+      <ThemedText style={styles.message}>
+        School announcements will appear here.
+      </ThemedText>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  message: {
+    marginTop: 16,
+  },
+});

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { StyleSheet, TextInput, TouchableOpacity } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function ChatScreen() {
+  const [message, setMessage] = useState('');
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title">Student Chat</ThemedText>
+      <ThemedView style={styles.chatArea}>
+        <ThemedText>Chat messages will appear here.</ThemedText>
+      </ThemedView>
+      <ThemedView style={styles.inputRow}>
+        <TextInput
+          style={styles.input}
+          placeholder="Type your message"
+          value={message}
+          onChangeText={setMessage}
+        />
+        <TouchableOpacity style={styles.sendButton}>
+          <ThemedText style={styles.sendText}>Send</ThemedText>
+        </TouchableOpacity>
+      </ThemedView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  chatArea: {
+    flex: 1,
+    marginVertical: 16,
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 8,
+    marginRight: 8,
+  },
+  sendButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: '#0a7ea4',
+    borderRadius: 8,
+  },
+  sendText: {
+    color: '#fff',
+  },
+});

--- a/app/(tabs)/payments.tsx
+++ b/app/(tabs)/payments.tsx
@@ -1,0 +1,40 @@
+import { Linking, StyleSheet, TouchableOpacity } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function PaymentsScreen() {
+  const handlePay = () => {
+    Linking.openURL('https://example.com/payments');
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title">Payments</ThemedText>
+      <ThemedText style={styles.balance}>Outstanding Balance: $0.00</ThemedText>
+      <TouchableOpacity style={styles.payButton} onPress={handlePay}>
+        <ThemedText style={styles.payText}>Go to Payment Portal</ThemedText>
+      </TouchableOpacity>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  balance: {
+    marginVertical: 16,
+  },
+  payButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: '#0a7ea4',
+    borderRadius: 8,
+    alignSelf: 'flex-start',
+  },
+  payText: {
+    color: '#fff',
+  },
+});

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -18,6 +18,9 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'bubble.left.and.bubble.right.fill': 'chat',
+  'megaphone.fill': 'campaign',
+  'creditcard.fill': 'credit-card',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- implement student chat, broadcast, and payments screens
- register new screens in tab navigation
- expand IconSymbol mappings for new tabs

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_685635c7ab0483249bdcbd2613b4850e