### PR TITLE
Apply royal blue, red, and gold scheme

### DIFF
--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
 import { StyleSheet, TextInput, TouchableOpacity } from 'react-native';
 
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 
 export default function ChatScreen() {
   const [message, setMessage] = useState('');
+  const theme = useColorScheme() ?? 'light';
 
   return (
     <ThemedView style={styles.container}>
@@ -20,7 +24,7 @@ export default function ChatScreen() {
           value={message}
           onChangeText={setMessage}
         />
-        <TouchableOpacity style={styles.sendButton}>
+        <TouchableOpacity style={[styles.sendButton, { backgroundColor: Colors[theme].tint }]}>
           <ThemedText style={styles.sendText}>Send</ThemedText>
         </TouchableOpacity>
       </ThemedView>
@@ -56,7 +60,6 @@ const styles = StyleSheet.create({
   sendButton: {
     paddingVertical: 8,
     paddingHorizontal: 12,
-    backgroundColor: '#0a7ea4',
     borderRadius: 8,
   },
   sendText: {

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -11,11 +11,11 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 export default function TabTwoScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
+      headerBackgroundColor={{ light: '#4169e1', dark: '#b22222' }}
       headerImage={
         <IconSymbol
           size={310}
-          color="#808080"
+          color="#ffd700"
           name="chevron.left.forwardslash.chevron.right"
           style={styles.headerImage}
         />
@@ -98,7 +98,7 @@ export default function TabTwoScreen() {
 
 const styles = StyleSheet.create({
   headerImage: {
-    color: '#808080',
+    color: '#ffd700',
     bottom: -90,
     left: -35,
     position: 'absolute',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -9,7 +9,7 @@ import { ThemedView } from '@/components/ThemedView';
 export default function HomeScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
+      headerBackgroundColor={{ light: '#ffd700', dark: '#4169e1' }}
       headerImage={
         <Image
           source={require('@/assets/images/partial-react-logo.png')}

--- a/app/(tabs)/payments.tsx
+++ b/app/(tabs)/payments.tsx
@@ -1,9 +1,13 @@
 import { Linking, StyleSheet, TouchableOpacity } from 'react-native';
 
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 
 export default function PaymentsScreen() {
+  const theme = useColorScheme() ?? 'light';
   const handlePay = () => {
     Linking.openURL('https://example.com/payments');
   };
@@ -12,7 +16,7 @@ export default function PaymentsScreen() {
     <ThemedView style={styles.container}>
       <ThemedText type="title">Payments</ThemedText>
       <ThemedText style={styles.balance}>Outstanding Balance: $0.00</ThemedText>
-      <TouchableOpacity style={styles.payButton} onPress={handlePay}>
+      <TouchableOpacity style={[styles.payButton, { backgroundColor: Colors[theme].tint }]} onPress={handlePay}>
         <ThemedText style={styles.payText}>Go to Payment Portal</ThemedText>
       </TouchableOpacity>
     </ThemedView>
@@ -30,7 +34,6 @@ const styles = StyleSheet.create({
   payButton: {
     paddingVertical: 12,
     paddingHorizontal: 16,
-    backgroundColor: '#0a7ea4',
     borderRadius: 8,
     alignSelf: 'flex-start',
   },

--- a/components/ThemedText.tsx
+++ b/components/ThemedText.tsx
@@ -16,6 +16,7 @@ export function ThemedText({
   ...rest
 }: ThemedTextProps) {
   const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
+  const tintColor = useThemeColor({}, 'tint');
 
   return (
     <Text
@@ -25,7 +26,7 @@ export function ThemedText({
         type === 'title' ? styles.title : undefined,
         type === 'defaultSemiBold' ? styles.defaultSemiBold : undefined,
         type === 'subtitle' ? styles.subtitle : undefined,
-        type === 'link' ? styles.link : undefined,
+        type === 'link' ? [styles.link, { color: tintColor }] : undefined,
         style,
       ]}
       {...rest}
@@ -55,6 +56,5 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#0a7ea4',
   },
 });

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -3,23 +3,23 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
+const tintColorLight = '#4169e1';
+const tintColorDark = '#ffd700';
 
 export const Colors = {
   light: {
     text: '#11181C',
     background: '#fff',
     tint: tintColorLight,
-    icon: '#687076',
-    tabIconDefault: '#687076',
+    icon: '#b22222',
+    tabIconDefault: '#b22222',
     tabIconSelected: tintColorLight,
   },
   dark: {
     text: '#ECEDEE',
     background: '#151718',
     tint: tintColorDark,
-    icon: '#9BA1A6',
+    icon: '#ffd700',
     tabIconDefault: '#9BA1A6',
     tabIconSelected: tintColorDark,
   },


### PR DESCRIPTION
## Summary
- implement a royal blue & gold accent color palette
- make link colors follow the tint color from the theme
- update chat and payment buttons with themed background colors
- refresh header colors and icon tones

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_68584891f1f48324bdba1a57096085af